### PR TITLE
Use native mysql2 promises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "7.8"
 script:
   - npm test
 notifications:
   email: dev@namshi.com
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mysql-promise
 
-Small promises wrapper for [`mysql2`](https://github.com/sidorares/node-mysql2), 
+Small wrapper for [`mysql2`](https://github.com/sidorares/node-mysql2),
 it's forked and compatible with [`mysql-promise`](https://github.com/martinj/node-mysql-promise).
 
 [![build status](https://travis-ci.org/namshi/node-mysql2-promise.svg)](http://travis-ci.org/namshi/node-mysql2-promise)
@@ -17,8 +17,10 @@ $ npm install mysql2-promise --save
 
 ## Example Usage of query
 
+`query()` uses [prepared-statements](https://github.com/sidorares/node-mysql2#prepared-statements).
+
 ``` js
-var db = require('mysql2-promise')();
+let db = require('mysql2-promise')();
 
 db.configure({
 	"host": "localhost",
@@ -34,7 +36,7 @@ db.query('UPDATE foo SET key = ?', ['value']).then(function () {
 });
 
 //using multiple databases, giving it a name 'second-db' so it can be retrieved inside other modules/files.
-var db2 = require('mysql-promise')('second-db');
+let db2 = require('mysql-promise')('second-db');
 
 db2.configure({
 	"host": "localhost",
@@ -52,10 +54,10 @@ db2.query('SELECT * FROM users').spread(function (users) {
 
 ## Example Usage of execute
 
-`execute()` function is similar to `query` but it use [prepared-statements](https://github.com/sidorares/node-mysql2#prepared-statements).
+`execute()` function is similar to `query` and it is kept here for backward compatibility with earlier versions of this library.
 
 ``` js
-var db = require('mysql2-promise')();
+let db = require('mysql2-promise')();
 
 db.configure({
 	"host": "localhost",
@@ -73,7 +75,7 @@ db.execute('SELECT * FROM users WHERE LIMIT = ?', [10]).spread(function (users) 
 ## Example usage of [namedPlaceholders]((https://github.com/sidorares/node-mysql2#named-placeholders))
 
 ``` js
-var db = require('mysql2-promise')();
+let db = require('mysql2-promise')();
 
 db.configure({
 	"host": "localhost",
@@ -92,6 +94,42 @@ db.execute('SELECT * FROM users WHERE LIMIT = :limit', {limit: 10}).spread(funct
 
 ```
 
+## Example usage of startTransaction, commit and rollback
+
+
+``` js
+let db = require('mysql2-promise')();
+
+db.configure({
+	"host": "localhost",
+	"user": "foo",
+	"password": "bar",
+	"database": "db"
+});
+
+let connection;
+
+db.startTransaction(30).then(conn => {
+	connection = con;
+}).catch(err) {
+	//handle error
+};
+
+//default timeout here is set to 20
+db.startTransaction().then(conn => {
+	connection = con;
+}).catch(err) {
+	//handle error
+};
+
+db.commit(connection).catch(err => {
+	//handle err
+});
+
+db.rollback(connection).catch(err => {
+	//handle err
+});
+```
 ## Credits
 
 This library is forked from [`mysql-promise`](https://github.com/martinj/node-mysql-promise)

--- a/index.js
+++ b/index.js
@@ -1,14 +1,25 @@
 /* jshint strict: true */
-
 'use strict';
 
-var Q = require('q');
-var mysql2 = require('mysql2');
+var mysql2 = require('mysql2/promise');
 var instances = {};
 
 function DB() {
   this.pool = null;
 }
+
+DB.prototype.getConnection = function () {
+  return this.pool.getConnection().then((conn)=> {
+    console.log('getting connection');
+    let exec = conn.execute;
+    conn.select = function(query, params) {
+      return exec.call(this, query, params).then((results) => {
+        return results[0];
+      });
+    };
+    return conn;
+  });
+};
 
 /**
  * Setup the Database connection pool for this instance
@@ -19,78 +30,98 @@ DB.prototype.configure = function (config) {
 };
 
 /**
- * Run DB query
+ * Run DB query, it uses prepared statements
  * @param  {String} query
  * @param  {Object} [params]
  * @return {Promise}
  */
 DB.prototype.query = function (query, params) {
-  params = params || {};
-  var db = this;
+  let connection;
 
-  return Q.Promise(function (resolve, reject) {
-    db.pool.getConnection(function (err, con) {
-      if (err) {
-        if (con) {
-          con.release();
-        }
+  return this.pool.getConnection().then((conn)=> {
+    console.log('getting connection');
+    connection = conn;
+    return connection.execute(query, params);
+  }).then((results) => {
+    if (connection && connection.connection) {
+      connection.connection.unprepare(query);
+      connection.release();
+      console.log('ok - released connection');
+    }
 
-        return reject(err);
-      }
+    return results[0];
+  }).catch(err => {
+    if (!connection) {
+      console.error('could not establish db connection', err.message);
+      throw err;
+    }
+    if (connection.connection) {
+      connection.connection.unprepare(query);
+    }
 
-      con.query(query, params, function (err) {
-        if (err) {
-          if (con) {
-            con.release();
-          }
+    connection.release();
+    console.error(`released connection, even with error in sql query execution. Error Message : ${err.message} - `, query, params);
 
-          return reject(err);
-        }
-
-        resolve([].splice.call(arguments, 1));
-        con.release();
-      });
-    });
+    throw err;
   });
 };
 
 /**
- * Run DB execute
+* Set Session wait timeout parameter to close connection if inactive
+* Initiate transaction so all the subsequent queries to the db are not written
+* to the database until commit is called
+* @param  {String} timeout
+*
+* @return {object} connection
+**/
+DB.prototype.startTransaction = function (timeout) {
+  timeout = timeout || 20;
+  let connection;
+  return DB.getConnection().then(conn => {
+    connection = conn;
+    return connection.query('SET SESSION wait_timeout = ?', [timeout]);
+  }).then(()=> {
+    return connection.query('START TRANSACTION');
+  }).then(() => {
+    return connection;
+  });
+};
+
+/**
+ * Rollback the current transaction
+ * @param  {Object} connection The connection object from startTransaction
+ */
+DB.prototype.rollback = function (connection) {
+  return connection.execute('ROLLBACK').then(()=> {
+    connection.release();
+  }).catch(err => {
+    connection.release();
+
+    throw err;
+  });
+};
+
+/**
+ * Commit the current transaction
+ * @param  {Object} connection The connection object from startTransaction
+ */
+DB.prototype.commit = function (connection) {
+  return connection.execute('COMMIT').then(()=> {
+    connection.release();
+  }).catch(err => {
+    connection.release();
+
+    throw err;
+  });
+};
+
+/**
+ * Run DB execute. This is kept here for backward compatibility.
  * @param  {String} query
  * @param  {Object} [params]
  * @return {Promise}
  */
-DB.prototype.execute = function (query, params) {
-  params = params || {};
-  var db = this;
-
-  return Q.Promise(function (resolve, reject) {
-    db.pool.getConnection(function (err, con) {
-      if (err) {
-        if (con) {
-          con.release();
-        }
-
-        return reject(err);
-      }
-
-      con.execute(query, params, function (err) {
-        if (err) {
-          if (con) {
-            con.unprepare(query);
-            con.release();
-          }
-
-          return reject(err);
-        }
-
-        resolve([].splice.call(arguments, 1));
-        con.unprepare(query);
-        con.release();
-      });
-    });
-  });
-};
+DB.prototype.execute = DB.prototype.query;
 
 module.exports = function (name) {
   name = name || '_default_';

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "keywords": [
     "mysql2",
     "promise",
-    "q",
     "mysql-promise"
   ],
   "author": "Hossam Fares <hossam.fares@namshi.com>",
@@ -28,11 +27,10 @@
     "url": "https://github.com/namshi/node-mysql2-promise/issues"
   },
   "dependencies": {
-    "mysql2": "^0.15.7",
-    "q": "^1.3.0"
+    "mysql2": "^1.2.0"
   },
   "devDependencies": {
-    "jshint": "~2.1.10",
+    "jshint": "^2.9.4",
     "mocha": "1.17.1",
     "release-it": "0.0.9",
     "should": "3.1.3"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,6 +9,9 @@ describe('mysql2-promise', function () {
     namedDb.should.equal(db('foo'));
     namedDb.should.have.property('query').which.is.a.Function;
     namedDb.should.have.property('execute').which.is.a.Function;
+    namedDb.should.have.property('startTransaction').which.is.a.Function;
+    namedDb.should.have.property('commit').which.is.a.Function;
+    namedDb.should.have.property('rollback').which.is.a.Function;
     defaultDb.should.equal(db());
     defaultDb.should.not.equal(namedDb);
     defaultDb.should.have.property('query').which.is.a.Function;


### PR DESCRIPTION
In this PR we got rid of Q in favor of native promise that is already supported in the recent version of mysql2. 

We also added a few more helper functions to the library: `startTransaction()`, `commit()` and `rollback()`.